### PR TITLE
Fix time validation for Discord timer bot

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,9 @@ client.on("interactionCreate", async (interaction) => {
   const duration = interaction.options.getInteger("duration");
   const timeStr = interaction.options.getString("starttime");
 
-  if (!/^\d{1,2}:\d{2}$/.test(timeStr)) {
-    return interaction.reply("❌ 시작 시각은 HH:mm 형식으로 입력해주세요.");
+  // Validate time format (HH:mm) with strict 24-hour range
+  if (!/^(?:[01]?\d|2[0-3]):[0-5]\d$/.test(timeStr)) {
+    return interaction.reply("❌ 시작 시각은 00:00~23:59 형식으로 입력해주세요.");
   }
 
   const startTime = parseTimeToFutureToday(timeStr);


### PR DESCRIPTION
## Summary
- tighten regex check for `starttime` so invalid hours/minutes aren't accepted

## Testing
- `node -c index.js`
- `node - <<'EOF'
const regex=/^(?:[01]?\d|2[0-3]):[0-5]\d$/;
console.log(regex.test('23:59'));
console.log(regex.test('25:00'));
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6845a1cb8658832ca585d76b4c4b5a41