### PR TITLE
Add status command for ongoing tests

### DIFF
--- a/deploy-command.js
+++ b/deploy-command.js
@@ -13,6 +13,10 @@ const commands = [
       opt.setName('starttime')
         .setDescription('시작 시각 (HH:mm)')
         .setRequired(true))
+  ,
+  new SlashCommandBuilder()
+    .setName('status')
+    .setDescription('진행 중인 코딩 테스트 확인')
 ].map(command => command.toJSON());
 
 const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { Client, GatewayIntentBits } = require("discord.js");
+const { Client, GatewayIntentBits, EmbedBuilder } = require("discord.js");
 require("dotenv").config();
 
 const client = new Client({
@@ -13,6 +13,7 @@ const predefinedSchedules = {
   30: [10],
 };
 const defaultSchedule = [30, 10];
+const ongoingTests = [];
 
 function parseTimeToFutureToday(timeStr) {
   const [hour, minute] = timeStr.split(":").map(Number);
@@ -29,37 +30,68 @@ client.once("ready", () => {
 
 client.on("interactionCreate", async (interaction) => {
   if (!interaction.isChatInputCommand()) return;
-  if (interaction.commandName !== "start") return;
 
-  const duration = interaction.options.getInteger("duration");
-  const timeStr = interaction.options.getString("starttime");
+  if (interaction.commandName === "start") {
+    const duration = interaction.options.getInteger("duration");
+    const timeStr = interaction.options.getString("starttime");
 
-  if (!/^\d{1,2}:\d{2}$/.test(timeStr)) {
-    return interaction.reply("❌ 시작 시각은 HH:mm 형식으로 입력해주세요.");
-  }
+    if (!/^\d{1,2}:\d{2}$/.test(timeStr)) {
+      return interaction.reply("❌ 시작 시각은 HH:mm 형식으로 입력해주세요.");
+    }
 
-  const startTime = parseTimeToFutureToday(timeStr);
-  const endTime = new Date(startTime.getTime() + duration * 60000);
-  const now = new Date();
-  const msUntilStart = startTime - now;
-  const schedule = predefinedSchedules[duration] || defaultSchedule;
+    const startTime = parseTimeToFutureToday(timeStr);
+    const endTime = new Date(startTime.getTime() + duration * 60000);
+    const now = new Date();
+    const msUntilStart = startTime - now;
+    const schedule = predefinedSchedules[duration] || defaultSchedule;
 
-  await interaction.reply(`🧠 ${startTime.toLocaleTimeString("ko-KR")}에 코딩테스트 시작 (⏱ ${duration}분)`);
-
-  setTimeout(() => {
-    interaction.followUp("🚀 코딩테스트 시작!");
-    schedule.forEach((offset) => {
-      const after = duration - offset;
-      if (after > 0) {
-        setTimeout(() => {
-          interaction.followUp(`⏳ ${offset}분 남았습니다!`);
-        }, after * 60000);
-      }
-    });
+    const testInfo = { startTime, endTime, userId: interaction.user.id, duration };
+    ongoingTests.push(testInfo);
     setTimeout(() => {
-      interaction.followUp("⛳ 코딩 테스트 종료!");
-    }, duration * 60000);
-  }, msUntilStart);
+      const idx = ongoingTests.indexOf(testInfo);
+      if (idx !== -1) ongoingTests.splice(idx, 1);
+    }, msUntilStart + duration * 60000);
+
+    await interaction.reply(`🧠 ${startTime.toLocaleTimeString("ko-KR")}에 코딩테스트 시작 (⏱ ${duration}분)`);
+
+    setTimeout(() => {
+      interaction.followUp("🚀 코딩테스트 시작!");
+      schedule.forEach((offset) => {
+        const after = duration - offset;
+        if (after > 0) {
+          setTimeout(() => {
+            interaction.followUp(`⏳ ${offset}분 남았습니다!`);
+          }, after * 60000);
+        }
+      });
+      setTimeout(() => {
+        interaction.followUp("⛳ 코딩 테스트 종료!");
+      }, duration * 60000);
+    }, msUntilStart);
+  } else if (interaction.commandName === "status") {
+    const now = new Date();
+    const active = ongoingTests.filter((t) => t.endTime > now);
+
+    if (active.length === 0) {
+      return interaction.reply({ content: "진행중인 코딩 테스트가 없습니다.", ephemeral: true });
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle("진행 중인 코딩 테스트")
+      .setColor(0x0099ff);
+
+    active.forEach((t, idx) => {
+      const start = t.startTime.toLocaleTimeString("ko-KR");
+      const end = t.endTime.toLocaleTimeString("ko-KR");
+      const remaining = Math.max(0, Math.ceil((t.endTime - now) / 60000));
+      embed.addFields({
+        name: `${idx + 1}. ${start} ~ ${end}`,
+        value: `<@${t.userId}> • 남은 시간 약 ${remaining}분`,
+      });
+    });
+
+    return interaction.reply({ embeds: [embed], ephemeral: true });
+  }
 });
 
 client.login(process.env.DISCORD_TOKEN);


### PR DESCRIPTION
## Summary
- track started coding tests in memory
- add `/status` slash command to show ongoing tests with an embed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845a2f91388832ca0aca0615270aebb