### PR TITLE
Refactor commands into modules

### DIFF
--- a/commands/start.js
+++ b/commands/start.js
@@ -1,0 +1,71 @@
+const { SlashCommandBuilder } = require('discord.js');
+const ongoingTests = require('../ongoing-tests');
+
+const predefinedSchedules = {
+  180: [90, 60, 30, 10],
+  120: [60, 30, 10],
+  90: [45, 30, 10],
+  60: [30, 10],
+  30: [10],
+};
+const defaultSchedule = [30, 10];
+
+function parseTimeToFutureToday(timeStr) {
+  const [hour, minute] = timeStr.split(':').map(Number);
+  const now = new Date();
+  const startTime = new Date(now);
+  startTime.setHours(hour, minute, 0, 0);
+  if (startTime < now) startTime.setDate(startTime.getDate() + 1);
+  return startTime;
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('start')
+    .setDescription('코딩 테스트 타이머 시작')
+    .addIntegerOption(opt =>
+      opt.setName('duration')
+        .setDescription('시험 시간 (분 단위)')
+        .setRequired(true))
+    .addStringOption(opt =>
+      opt.setName('starttime')
+        .setDescription('시작 시각 (HH:mm)')
+        .setRequired(true)),
+  async execute(interaction) {
+    const duration = interaction.options.getInteger('duration');
+    const timeStr = interaction.options.getString('starttime');
+
+    if (!/^(?:[01]?\d|2[0-3]):[0-5]\d$/.test(timeStr)) {
+      return interaction.reply('❌ 시작 시각은 00:00~23:59 형식으로 입력해주세요.');
+    }
+    const startTime = parseTimeToFutureToday(timeStr);
+    const endTime = new Date(startTime.getTime() + duration * 60000);
+    const now = new Date();
+    const msUntilStart = startTime - now;
+    const schedule = predefinedSchedules[duration] || defaultSchedule;
+
+    const testInfo = { startTime, endTime, userId: interaction.user.id, duration };
+    ongoingTests.push(testInfo);
+    setTimeout(() => {
+      const idx = ongoingTests.indexOf(testInfo);
+      if (idx !== -1) ongoingTests.splice(idx, 1);
+    }, msUntilStart + duration * 60000);
+
+    await interaction.reply(`🧠 ${startTime.toLocaleTimeString('ko-KR')}에 코딩테스트 시작 (⏱ ${duration}분)`);
+
+    setTimeout(() => {
+      interaction.followUp('🚀 코딩테스트 시작!');
+      schedule.forEach((offset) => {
+        const after = duration - offset;
+        if (after > 0) {
+          setTimeout(() => {
+            interaction.followUp(`⏳ ${offset}분 남았습니다!`);
+          }, after * 60000);
+        }
+      });
+      setTimeout(() => {
+        interaction.followUp('⛳ 코딩 테스트 종료!');
+      }, duration * 60000);
+    }, msUntilStart);
+  },
+};

--- a/commands/status.js
+++ b/commands/status.js
@@ -1,0 +1,32 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const ongoingTests = require('../ongoing-tests');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('status')
+    .setDescription('진행 중인 코딩 테스트 확인'),
+  async execute(interaction) {
+    const now = new Date();
+    const active = ongoingTests.filter(t => t.endTime > now);
+
+    if (active.length === 0) {
+      return interaction.reply({ content: '진행중인 코딩 테스트가 없습니다.', ephemeral: true });
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle('진행 중인 코딩 테스트')
+      .setColor(0x0099ff);
+
+    active.forEach((t, idx) => {
+      const start = t.startTime.toLocaleTimeString('ko-KR');
+      const end = t.endTime.toLocaleTimeString('ko-KR');
+      const remaining = Math.max(0, Math.ceil((t.endTime - now) / 60000));
+      embed.addFields({
+        name: `${idx + 1}. ${start} ~ ${end}`,
+        value: `<@${t.userId}> • 남은 시간 약 ${remaining}분`,
+      });
+    });
+
+    return interaction.reply({ embeds: [embed], ephemeral: true });
+  },
+};

--- a/deploy-command.js
+++ b/deploy-command.js
@@ -1,23 +1,18 @@
-const { REST, Routes, SlashCommandBuilder } = require('discord.js');
+const { REST, Routes } = require('discord.js');
+const fs = require('fs');
+const path = require('path');
 require('dotenv').config();
 
-const commands = [
-  new SlashCommandBuilder()
-    .setName('start')
-    .setDescription('코딩 테스트 타이머 시작')
-    .addIntegerOption(opt =>
-      opt.setName('duration')
-        .setDescription('시험 시간 (분 단위)')
-        .setRequired(true))
-    .addStringOption(opt =>
-      opt.setName('starttime')
-        .setDescription('시작 시각 (HH:mm)')
-        .setRequired(true))
-  ,
-  new SlashCommandBuilder()
-    .setName('status')
-    .setDescription('진행 중인 코딩 테스트 확인')
-].map(command => command.toJSON());
+const commands = [];
+const commandsPath = path.join(__dirname, 'commands');
+const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+
+for (const file of commandFiles) {
+  const command = require(`./commands/${file}`);
+  if ('data' in command) {
+    commands.push(command.data.toJSON());
+  }
+}
 
 const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);
 

--- a/index.js
+++ b/index.js
@@ -1,95 +1,42 @@
-const { Client, GatewayIntentBits, EmbedBuilder } = require("discord.js");
-require("dotenv").config();
+const { Client, GatewayIntentBits } = require('discord.js');
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config();
 
 const client = new Client({
   intents: [GatewayIntentBits.Guilds],
 });
 
-const predefinedSchedules = {
-  180: [90, 60, 30, 10],
-  120: [60, 30, 10],
-  90: [45, 30, 10],
-  60: [30, 10],
-  30: [10],
-};
-const defaultSchedule = [30, 10];
-const ongoingTests = [];
-
-function parseTimeToFutureToday(timeStr) {
-  const [hour, minute] = timeStr.split(":").map(Number);
-  const now = new Date();
-  const startTime = new Date(now);
-  startTime.setHours(hour, minute, 0, 0);
-  if (startTime < now) startTime.setDate(startTime.getDate() + 1);
-  return startTime;
+client.commands = new Map();
+const commandsPath = path.join(__dirname, 'commands');
+const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+for (const file of commandFiles) {
+  const command = require(`./commands/${file}`);
+  if ('data' in command && 'execute' in command) {
+    client.commands.set(command.data.name, command);
+  }
 }
 
-client.once("ready", () => {
+client.once('ready', () => {
   console.log(`✅ 봇 로그인: ${client.user.tag}`);
 });
 
-client.on("interactionCreate", async (interaction) => {
+client.on('interactionCreate', async (interaction) => {
   if (!interaction.isChatInputCommand()) return;
 
-  if (interaction.commandName === "start") {
-    const duration = interaction.options.getInteger("duration");
-    const timeStr = interaction.options.getString("starttime");
+  const command = interaction.client.commands.get(interaction.commandName);
+  if (!command) return;
 
-    if (!/^(?:[01]?\d|2[0-3]):[0-5]\d$/.test(timeStr)) {
-      return interaction.reply("❌ 시작 시각은 00:00~23:59 형식으로 입력해주세요.");
+  try {
+    await command.execute(interaction);
+  } catch (error) {
+    console.error(error);
+    const reply = { content: '❌ 명령 실행 중 오류가 발생했습니다.', ephemeral: true };
+    if (interaction.replied || interaction.deferred) {
+      await interaction.followUp(reply);
+    } else {
+      await interaction.reply(reply);
     }
-    const startTime = parseTimeToFutureToday(timeStr);
-    const endTime = new Date(startTime.getTime() + duration * 60000);
-    const now = new Date();
-    const msUntilStart = startTime - now;
-    const schedule = predefinedSchedules[duration] || defaultSchedule;
-
-    const testInfo = { startTime, endTime, userId: interaction.user.id, duration };
-    ongoingTests.push(testInfo);
-    setTimeout(() => {
-      const idx = ongoingTests.indexOf(testInfo);
-      if (idx !== -1) ongoingTests.splice(idx, 1);
-    }, msUntilStart + duration * 60000);
-
-    await interaction.reply(`🧠 ${startTime.toLocaleTimeString("ko-KR")}에 코딩테스트 시작 (⏱ ${duration}분)`);
-
-    setTimeout(() => {
-      interaction.followUp("🚀 코딩테스트 시작!");
-      schedule.forEach((offset) => {
-        const after = duration - offset;
-        if (after > 0) {
-          setTimeout(() => {
-            interaction.followUp(`⏳ ${offset}분 남았습니다!`);
-          }, after * 60000);
-        }
-      });
-      setTimeout(() => {
-        interaction.followUp("⛳ 코딩 테스트 종료!");
-      }, duration * 60000);
-    }, msUntilStart);
-  } else if (interaction.commandName === "status") {
-    const now = new Date();
-    const active = ongoingTests.filter((t) => t.endTime > now);
-
-    if (active.length === 0) {
-      return interaction.reply({ content: "진행중인 코딩 테스트가 없습니다.", ephemeral: true });
-    }
-
-    const embed = new EmbedBuilder()
-      .setTitle("진행 중인 코딩 테스트")
-      .setColor(0x0099ff);
-
-    active.forEach((t, idx) => {
-      const start = t.startTime.toLocaleTimeString("ko-KR");
-      const end = t.endTime.toLocaleTimeString("ko-KR");
-      const remaining = Math.max(0, Math.ceil((t.endTime - now) / 60000));
-      embed.addFields({
-        name: `${idx + 1}. ${start} ~ ${end}`,
-        value: `<@${t.userId}> • 남은 시간 약 ${remaining}분`,
-      });
-    });
-
-    return interaction.reply({ embeds: [embed], ephemeral: true });
   }
 });
 

--- a/ongoing-tests.js
+++ b/ongoing-tests.js
@@ -1,0 +1,1 @@
+module.exports = [];


### PR DESCRIPTION
## Summary
- organize commands under `commands` directory
- extract command logic for `start` and `status`
- update command deployment to load from modules
- rewrite `index.js` to load and run command modules
- share ongoing test data via a separate module

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845ac1816e8832cb82d2723a57400ff