### PR TITLE
Add terminate command for active tests

### DIFF
--- a/deploy-command.js
+++ b/deploy-command.js
@@ -17,6 +17,10 @@ const commands = [
   new SlashCommandBuilder()
     .setName('status')
     .setDescription('진행 중인 코딩 테스트 확인')
+  ,
+  new SlashCommandBuilder()
+    .setName('terminate')
+    .setDescription('진행 중인 테스트 강제 종료')
 ].map(command => command.toJSON());
 
 const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);


### PR DESCRIPTION
## Summary
- add new `/terminate` slash command that lists ongoing tests with a "종료" button
- implement button interaction to force stop a selected test and notify the channel
- register `/terminate` command in deploy script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845afe8503c832cad22fbfdab1d8864