### PR TITLE
Add terminate command

### DIFF
--- a/commands/start.js
+++ b/commands/start.js
@@ -44,28 +44,32 @@ module.exports = {
     const msUntilStart = startTime - now;
     const schedule = predefinedSchedules[duration] || defaultSchedule;
 
-    const testInfo = { startTime, endTime, userId: interaction.user.id, duration };
-    ongoingTests.push(testInfo);
-    setTimeout(() => {
-      const idx = ongoingTests.indexOf(testInfo);
-      if (idx !== -1) ongoingTests.splice(idx, 1);
-    }, msUntilStart + duration * 60000);
+  const label = `${startTime.toLocaleTimeString('ko-KR')} ~ ${endTime.toLocaleTimeString('ko-KR')}`;
+  const testInfo = { startTime, endTime, userId: interaction.user.id, duration, timeouts: [], label };
+  ongoingTests.push(testInfo);
 
-    await interaction.reply(`🧠 ${startTime.toLocaleTimeString('ko-KR')}에 코딩테스트 시작 (⏱ ${duration}분)`);
+  await interaction.reply(`🧠 ${startTime.toLocaleTimeString('ko-KR')}에 코딩테스트 시작 (⏱ ${duration}분)`);
 
-    setTimeout(() => {
-      interaction.followUp('🚀 코딩테스트 시작!');
-      schedule.forEach((offset) => {
-        const after = duration - offset;
-        if (after > 0) {
-          setTimeout(() => {
-            interaction.followUp(`⏳ ${offset}분 남았습니다!`);
-          }, after * 60000);
-        }
-      });
-      setTimeout(() => {
-        interaction.followUp('⛳ 코딩 테스트 종료!');
-      }, duration * 60000);
-    }, msUntilStart);
+  const startTimeout = setTimeout(() => {
+    interaction.followUp('🚀 코딩테스트 시작!');
+  }, msUntilStart);
+  testInfo.timeouts.push(startTimeout);
+
+  schedule.forEach((offset) => {
+    const after = duration - offset;
+    if (after > 0) {
+      const t = setTimeout(() => {
+        interaction.followUp(`⏳ ${offset}분 남았습니다!`);
+      }, msUntilStart + after * 60000);
+      testInfo.timeouts.push(t);
+    }
+  });
+
+  const endTimeout = setTimeout(() => {
+    interaction.followUp('⛳ 코딩 테스트 종료!');
+    const idx = ongoingTests.indexOf(testInfo);
+    if (idx !== -1) ongoingTests.splice(idx, 1);
+  }, msUntilStart + duration * 60000);
+  testInfo.timeouts.push(endTimeout);
   },
 };

--- a/commands/terminate.js
+++ b/commands/terminate.js
@@ -1,0 +1,49 @@
+const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const ongoingTests = require('../ongoing-tests');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('terminate')
+    .setDescription('진행 중인 코딩 테스트 강제 종료'),
+  async execute(interaction) {
+    const now = new Date();
+    const active = ongoingTests.filter(t => t.endTime > now);
+
+    if (active.length === 0) {
+      return interaction.reply({ content: '진행중인 코딩 테스트가 없습니다.', ephemeral: true });
+    }
+
+    const description = active.map((t, idx) => {
+      const label = t.label || `${t.startTime.toLocaleTimeString('ko-KR')} ~ ${t.endTime.toLocaleTimeString('ko-KR')}`;
+      const remaining = Math.max(0, Math.ceil((t.endTime - now) / 60000));
+      return `${idx + 1}. ${label} • 남은 시간 약 ${remaining}분`;
+    }).join('\n');
+
+    const components = active.map((t, idx) =>
+      new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+          .setCustomId(`terminate_${idx}`)
+          .setLabel(`${idx + 1}번 종료`)
+          .setStyle(ButtonStyle.Danger),
+      )
+    );
+
+    return interaction.reply({
+      content: description,
+      components,
+      ephemeral: true,
+    });
+  },
+  async handleButton(interaction) {
+    const idx = parseInt(interaction.customId.split('_')[1], 10);
+    const test = ongoingTests[idx];
+    if (!test) {
+      return interaction.update({ content: '이미 종료된 테스트입니다.', components: [] });
+    }
+    test.timeouts.forEach(t => clearTimeout(t));
+    ongoingTests.splice(idx, 1);
+    const testName = test.label || `${test.startTime.toLocaleTimeString('ko-KR')} ~ ${test.endTime.toLocaleTimeString('ko-KR')}`;
+    await interaction.update({ content: `${testName} 테스트 종료`, components: [] });
+    await interaction.channel.send(`**${testName} 테스트가 <@${interaction.user.id}>에 의해 강제 종료되었습니다.**`);
+  },
+};

--- a/index.js
+++ b/index.js
@@ -22,20 +22,30 @@ client.once('ready', () => {
 });
 
 client.on('interactionCreate', async (interaction) => {
-  if (!interaction.isChatInputCommand()) return;
+  if (interaction.isChatInputCommand()) {
+    const command = interaction.client.commands.get(interaction.commandName);
+    if (!command) return;
 
-  const command = interaction.client.commands.get(interaction.commandName);
-  if (!command) return;
-
-  try {
-    await command.execute(interaction);
-  } catch (error) {
-    console.error(error);
-    const reply = { content: '❌ 명령 실행 중 오류가 발생했습니다.', ephemeral: true };
-    if (interaction.replied || interaction.deferred) {
-      await interaction.followUp(reply);
-    } else {
-      await interaction.reply(reply);
+    try {
+      await command.execute(interaction);
+    } catch (error) {
+      console.error(error);
+      const reply = { content: '❌ 명령 실행 중 오류가 발생했습니다.', ephemeral: true };
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp(reply);
+      } else {
+        await interaction.reply(reply);
+      }
+    }
+  } else if (interaction.isButton()) {
+    const [cmdName] = interaction.customId.split('_');
+    const command = interaction.client.commands.get(cmdName);
+    if (command && typeof command.handleButton === 'function') {
+      try {
+        await command.handleButton(interaction);
+      } catch (error) {
+        console.error(error);
+      }
     }
   }
 });


### PR DESCRIPTION
## Summary
- add `/terminate` command with buttons to stop running tests
- store scheduled timeout handles for each test in `start` command
- handle button interactions in `terminate.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845b26fe600832caeb4886994a26e57