### PR TITLE
Implement participant scoring flow

### DIFF
--- a/commands/start.ts
+++ b/commands/start.ts
@@ -1,5 +1,17 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ButtonInteraction,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  ModalSubmitInteraction,
+} from 'discord.js';
 import ongoingTests from '../ongoing-tests';
+import { concludeTest } from '../test-utils';
 
 const predefinedSchedules = {
   180: [90, 60, 30, 10],
@@ -30,10 +42,15 @@ export default {
     .addStringOption(opt =>
       opt.setName('starttime')
         .setDescription('시작 시각 (HH:mm)')
+        .setRequired(true))
+    .addIntegerOption(opt =>
+      opt.setName('participants')
+        .setDescription('참가 인원 수')
         .setRequired(true)),
   async execute(interaction: ChatInputCommandInteraction) {
     const duration = interaction.options.getInteger('duration', true);
     const timeStr = interaction.options.getString('starttime', true);
+    const participants = interaction.options.getInteger('participants', true);
 
     if (!/^(?:[01]?\d|2[0-3]):[0-5]\d$/.test(timeStr)) {
       return interaction.reply('❌ 시작 시각은 00:00~23:59 형식으로 입력해주세요.');
@@ -45,7 +62,18 @@ export default {
     const schedule = (predefinedSchedules as any)[duration] || defaultSchedule;
 
   const label = `${startTime.toLocaleTimeString('ko-KR')} ~ ${endTime.toLocaleTimeString('ko-KR')}`;
-  const testInfo = { startTime, endTime, userId: interaction.user.id, duration, timeouts: [] as NodeJS.Timeout[], label };
+  const testInfo = {
+    startTime,
+    endTime,
+    userId: interaction.user.id,
+    duration,
+    timeouts: [] as NodeJS.Timeout[],
+    label,
+    participants,
+    channelId: interaction.channelId,
+    scores: {} as Record<string, { name: string; score: number }>,
+    ended: false,
+  };
   ongoingTests.push(testInfo);
 
   await interaction.reply(`🧠 ${startTime.toLocaleTimeString('ko-KR')}에 코딩테스트 시작 (⏱ ${duration}분)`);
@@ -66,10 +94,71 @@ export default {
   });
 
   const endTimeout = setTimeout(() => {
-    interaction.followUp('⛳ 코딩 테스트 종료!');
-    const idx = ongoingTests.indexOf(testInfo);
-    if (idx !== -1) ongoingTests.splice(idx, 1);
+    concludeTest(testInfo, interaction.channel as any);
   }, msUntilStart + duration * 60000);
   testInfo.timeouts.push(endTimeout);
+  },
+  async handleButton(interaction: ButtonInteraction) {
+    let data: any;
+    try {
+      data = JSON.parse(interaction.customId);
+    } catch (e) {
+      return interaction.reply({ content: '버튼 정보 파싱 오류', ephemeral: true });
+    }
+    if (data.action !== 'score') return;
+    const test = ongoingTests[data.idx];
+    if (!test) {
+      return interaction.reply({ content: '테스트 정보를 찾을 수 없습니다.', ephemeral: true });
+    }
+    if (!test.ended) {
+      return interaction.reply({ content: '아직 종료되지 않은 테스트입니다.', ephemeral: true });
+    }
+    const modal = new ModalBuilder()
+      .setCustomId(JSON.stringify({ cmd: 'start', action: 'submitScore', idx: data.idx }))
+      .setTitle('점수 입력');
+    const input = new TextInputBuilder()
+      .setCustomId('score')
+      .setLabel('본인 점수')
+      .setStyle(TextInputStyle.Short)
+      .setRequired(true);
+    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(input));
+    await interaction.showModal(modal);
+  },
+  async handleModal(interaction: ModalSubmitInteraction) {
+    let data: any;
+    try {
+      data = JSON.parse(interaction.customId);
+    } catch (e) {
+      return interaction.reply({ content: '모달 정보 파싱 오류', ephemeral: true });
+    }
+    if (data.action !== 'submitScore') return;
+    const test = ongoingTests[data.idx];
+    if (!test) {
+      return interaction.reply({ content: '테스트 정보를 찾을 수 없습니다.', ephemeral: true });
+    }
+    const value = interaction.fields.getTextInputValue('score');
+    const score = parseInt(value, 10);
+    if (isNaN(score)) {
+      return interaction.reply({ content: '숫자 점수를 입력해주세요.', ephemeral: true });
+    }
+    if (test.scores[interaction.user.id]) {
+      return interaction.reply({ content: '이미 점수를 제출하셨습니다.', ephemeral: true });
+    }
+    test.scores[interaction.user.id] = { name: interaction.user.username, score };
+    await interaction.reply({ content: '점수가 기록되었습니다.', ephemeral: true });
+    if (Object.keys(test.scores).length >= test.participants) {
+      const results = Object.values(test.scores).sort((a, b) => b.score - a.score);
+      const medals = ['🥇', '🥈', '🥉'];
+      const lines = results.map((r, i) => `${medals[i] || `${i + 1}.`} ${r.name} - ${r.score}점`);
+      const message = `🏁 코딩테스트 결과\n\n${lines.join('  \n')}`;
+      const channel = interaction.client.channels.cache.get(test.channelId) as any;
+      if (channel) {
+        channel.send(message);
+      } else {
+        interaction.followUp({ content: message });
+      }
+      const idx = ongoingTests.indexOf(test);
+      if (idx !== -1) ongoingTests.splice(idx, 1);
+    }
   },
 };

--- a/commands/start.ts
+++ b/commands/start.ts
@@ -67,7 +67,7 @@ export default {
     endTime,
     userId: interaction.user.id,
     duration,
-    timeouts: [] as NodeJS.Timeout[],
+    timeouts: [] as any[],
     label,
     participants,
     channelId: interaction.channelId,
@@ -147,7 +147,8 @@ export default {
     test.scores[interaction.user.id] = { name: interaction.user.username, score };
     await interaction.reply({ content: '점수가 기록되었습니다.', ephemeral: true });
     if (Object.keys(test.scores).length >= test.participants) {
-      const results = Object.values(test.scores).sort((a, b) => b.score - a.score);
+      const scores = test.scores as Record<string, { name: string; score: number }>;
+      const results = Object.values(scores).sort((a, b) => b.score - a.score);
       const medals = ['🥇', '🥈', '🥉'];
       const lines = results.map((r, i) => `${medals[i] || `${i + 1}.`} ${r.name} - ${r.score}점`);
       const message = `🏁 코딩테스트 결과\n\n${lines.join('  \n')}`;

--- a/commands/terminate.ts
+++ b/commands/terminate.ts
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, ChatInputCommandInteraction, ButtonInteraction } from 'discord.js';
 import ongoingTests from '../ongoing-tests';
+import { concludeTest } from '../test-utils';
 
 export default {
   data: new SlashCommandBuilder()
@@ -46,8 +47,7 @@ export default {
     if (!test) {
       return interaction.update({ content: '이미 종료된 테스트입니다.', components: [] });
     }
-    test.timeouts.forEach((t: NodeJS.Timeout) => clearTimeout(t));
-    ongoingTests.splice(idx, 1);
+    concludeTest(test, interaction.channel as any);
     const testName = test.label || `${test.startTime.toLocaleTimeString('ko-KR')} ~ ${test.endTime.toLocaleTimeString('ko-KR')}`;
     await interaction.update({ content: `${testName} 테스트 종료`, components: [] });
     await (interaction.channel as any).send(`**${testName} 테스트가 <@${interaction.user.id}>에 의해 강제 종료되었습니다.**`);

--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,8 @@ client.on('interactionCreate', async (interaction: Interaction) => {
     await handleCommand(interaction as any);
   } else if (interaction.isButton()) {
     await handleButton(interaction as any);
+  } else if (interaction.isModalSubmit()) {
+    await handleModal(interaction as any);
   }
 });
 
@@ -61,6 +63,24 @@ async function handleButton(interaction: any) {
   if (command && typeof command.handleButton === 'function') {
     try {
       await command.handleButton(interaction);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+}
+
+async function handleModal(interaction: any) {
+  let data;
+  try {
+    data = JSON.parse(interaction.customId);
+  } catch (e) {
+    console.error('모달 customId 파싱 오류:', e);
+    return;
+  }
+  const command = (interaction.client as any).commands.get(data?.cmd);
+  if (command && typeof command.handleModal === 'function') {
+    try {
+      await command.handleModal(interaction);
     } catch (error) {
       console.error(error);
     }

--- a/test-utils.ts
+++ b/test-utils.ts
@@ -1,0 +1,21 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, TextBasedChannel } from 'discord.js';
+import ongoingTests from './ongoing-tests';
+
+export function concludeTest(test: any, channel: TextBasedChannel) {
+  if (test.ended) return;
+  test.ended = true;
+  test.timeouts.forEach((t: NodeJS.Timeout) => clearTimeout(t));
+  const idx = ongoingTests.indexOf(test);
+  if (idx === -1) return;
+  channel.send({
+    content: '⛳ 코딩 테스트 종료!',
+    components: [
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(JSON.stringify({ cmd: 'start', action: 'score', idx }))
+          .setLabel('점수 입력')
+          .setStyle(ButtonStyle.Primary),
+      ),
+    ] as any,
+  });
+}

--- a/test-utils.ts
+++ b/test-utils.ts
@@ -1,10 +1,10 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, TextBasedChannel } from 'discord.js';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
 import ongoingTests from './ongoing-tests';
 
-export function concludeTest(test: any, channel: TextBasedChannel) {
+export function concludeTest(test: any, channel: any) {
   if (test.ended) return;
   test.ended = true;
-  test.timeouts.forEach((t: NodeJS.Timeout) => clearTimeout(t));
+  test.timeouts.forEach((t: any) => clearTimeout(t));
   const idx = ongoingTests.indexOf(test);
   if (idx === -1) return;
   channel.send({


### PR DESCRIPTION
## Summary
- extend `/start` to accept `participants` option
- store extra info for score collection and end tests with a modal button
- handle score submissions via modal and display sorted results
- unify forced and normal test endings
- support modal interactions in bot event handler

## Testing
- `npm run build` *(fails: Cannot find module 'discord.js')*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846ce59a920832c89efba29e31334de